### PR TITLE
Fix Bug that Holds with 0 BPM Has None Judgment Point

### DIFF
--- a/Assets/Scripts/Gameplay/Chart/ArcChart.cs
+++ b/Assets/Scripts/Gameplay/Chart/ArcChart.cs
@@ -639,7 +639,6 @@ namespace Arcade.Gameplay.Chart
 			int u = 0;
 			double bpm = ArcTimingManager.Instance.CalculateBpmByTiming(Timing, TimingGroup);
 			bpm = Math.Abs(bpm);
-			if (bpm == 0) return;
 			double interval = 60000f / bpm / (bpm >= 255 ? 1 : 2) / ArcGameplayManager.Instance.TimingPointDensityFactor;
 			int total = (int)((EndTiming - Timing) / interval);
 			if ((u ^ 1) >= total)


### PR DESCRIPTION
In Arcaea, holds with 0 BPM actually has single judgement point. We can find one 0BPM-hold in PRAGMATISM beyond chart at 1424cb. Currently, Arcade Plus does not think this hold has any judgement point. The fork is to fixed this bug.